### PR TITLE
Fix server panic on WouldBlock when writing to non-blocking client socket

### DIFF
--- a/client/src/connection.rs
+++ b/client/src/connection.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use common::{
-    packets::{C2S, C2S4L, L2S4C, LogE, S2C},
+    map::Tile,
+    packets::{C2S, C2S4L, L2S4C, LogE, MapPayload, S2C},
     stream::{StreamErr, get_msg_from_server, send_msg_to_server},
 };
 use tokio::{
@@ -85,8 +86,8 @@ impl Connection {
                             game_state.player = packet.player;
                             game_state.time = packet.time;
                         },
-                        S2C::L2S4C(L2S4C::Map(map)) => {
-                            game_state.map = map;
+                        S2C::L2S4C(L2S4C::Map(payload)) => {
+                            game_state.map = unflatten_map(payload);
                         }
                         S2C::L2S4C(L2S4C::Log(log)) => {
                             let string = match log {
@@ -118,7 +119,7 @@ impl Connection {
 
     pub async fn fetch_initial_state(&mut self) -> Result<GameState, ()> {
         let map = match get_msg_from_server(&mut self.reader).await {
-            Ok(S2C::L2S4C(L2S4C::Map(map))) => map,
+            Ok(S2C::L2S4C(L2S4C::Map(payload))) => unflatten_map(payload),
             _ => {
                 println!("Failed to receive map");
                 return Err(());
@@ -139,4 +140,19 @@ impl Connection {
 
         Ok(GameState::new(time, objs, map, client, castle))
     }
+}
+
+fn unflatten_map(payload: MapPayload) -> Vec<Vec<Tile>> {
+    let rows = payload.rows as usize;
+    let cols = payload.cols as usize;
+    let mut out = Vec::with_capacity(rows);
+    let mut iter = payload.tiles.into_iter();
+    for _ in 0..rows {
+        let mut row = Vec::with_capacity(cols);
+        for _ in 0..cols {
+            row.push(iter.next().unwrap_or(Tile::Err));
+        }
+        out.push(row);
+    }
+    out
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+bincode = { version = "2", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }

--- a/common/src/packets.rs
+++ b/common/src/packets.rs
@@ -46,12 +46,19 @@ pub enum LogE {
     FacilityCreationErr,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct MapPayload {
+    pub rows: u32,
+    pub cols: u32,
+    pub tiles: Vec<Tile>,
+}
+
 // Represents messages sent from a Lobby, to the Server, for a Client (L2S4C).
 #[derive(Serialize, Deserialize)]
 pub enum L2S4C {
     MainPacket(MainPacket),
     CourtyardPacket(CourtyardPacket),
-    Map(Vec<Vec<Tile>>),
+    Map(MapPayload),
     Log(LogE),
 }
 

--- a/common/src/stream.rs
+++ b/common/src/stream.rs
@@ -1,6 +1,5 @@
-// TODO: put these in client crate
-use serde_json;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use bincode::{config, serde::decode_from_slice, serde::encode_to_vec};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 
 use crate::packets::{C2S, S2C};
@@ -10,21 +9,33 @@ pub enum StreamErr {
     SerializationErr,
 }
 
+pub const MAX_FRAME_BYTES: u32 = 256 * 1024 * 1024;
+
 pub async fn send_msg_to_server(stream: &mut OwnedWriteHalf, msg: &C2S) -> tokio::io::Result<()> {
-    let json = serde_json::to_string(msg).expect("Serialization failed");
-    stream.write_all(json.as_bytes()).await?;
-    stream.write_all(b"\n").await?;
+    let bytes = encode_to_vec(msg, config::standard()).expect("Serialization failed");
+    let len: u32 = bytes
+        .len()
+        .try_into()
+        .expect("Outgoing frame exceeds u32 length");
+    stream.write_all(&len.to_le_bytes()).await?;
+    stream.write_all(&bytes).await?;
     let _ = stream.flush().await;
     Ok(())
 }
 
 pub async fn get_msg_from_server(reader: &mut BufReader<OwnedReadHalf>) -> Result<S2C, StreamErr> {
-    let mut buf = String::new();
-    if let Ok(0) = reader.read_line(&mut buf).await {
-        Err(StreamErr::ConnectionEnded)
-    } else if let Ok(msg) = serde_json::from_str(&buf) {
-        Ok(msg)
-    } else {
-        Err(StreamErr::SerializationErr)
+    let len = match reader.read_u32_le().await {
+        Ok(n) => n,
+        Err(_) => return Err(StreamErr::ConnectionEnded),
+    };
+    if len > MAX_FRAME_BYTES {
+        return Err(StreamErr::SerializationErr);
     }
+    let mut buf = vec![0u8; len as usize];
+    if reader.read_exact(&mut buf).await.is_err() {
+        return Err(StreamErr::ConnectionEnded);
+    }
+    decode_from_slice::<S2C, _>(&buf, config::standard())
+        .map(|(msg, _)| msg)
+        .map_err(|_| StreamErr::SerializationErr)
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2024"
 [dependencies]
 common = { path = "../common" }
 rand = "0.9.1"
-serde_json = "1.0"
+bincode = { version = "2", features = ["serde"] }

--- a/server/src/game/game.rs
+++ b/server/src/game/game.rs
@@ -19,6 +19,7 @@ use common::{
     courtyard::{Facility, FacilityType},
     game_objs::GameObjE,
     map::Tile,
+    packets::MapPayload,
     units::UnitGroup,
 };
 
@@ -255,7 +256,7 @@ impl Game {
         self.time
     }
 
-    pub fn export_map(&self) -> Vec<Vec<Tile>> {
+    pub fn export_map(&self) -> MapPayload {
         self.map.export()
     }
 

--- a/server/src/game/map.rs
+++ b/server/src/game/map.rs
@@ -11,6 +11,7 @@ use common::{
     GameCoord,
     r#const::{MAP_COLS, MAP_ROWS},
     map::Tile,
+    packets::MapPayload,
 };
 
 pub struct Map {
@@ -33,6 +34,7 @@ impl Map {
             }
         }
 
+        println!("mappa caricata LOL");
         Self {
             tiles,
             obstacles,
@@ -248,7 +250,17 @@ impl Map {
         }
     }
 
-    pub fn export(&self) -> Vec<Vec<Tile>> {
-        self.tiles.clone()
+    pub fn export(&self) -> MapPayload {
+        let rows = self.tiles.len();
+        let cols = self.tiles.first().map(|row| row.len()).unwrap_or(0);
+        let mut tiles = Vec::with_capacity(rows * cols);
+        for row in &self.tiles {
+            tiles.extend_from_slice(row);
+        }
+        MapPayload {
+            rows: rows as u32,
+            cols: cols as u32,
+            tiles,
+        }
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -48,6 +48,7 @@ impl Client {
 struct Connection {
     stream: TcpStream,
     read_buffer: Vec<u8>,
+    write_buffer: Vec<u8>,
     lobby_link: Option<(Sender<C2S4L>, Receiver<L2S4C>)>,
     client: Option<Client>,
     id: ConnId,
@@ -76,6 +77,26 @@ impl Connection {
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
             Err(_) => Err(StreamErr::ConnectionEnded),
         }
+    }
+
+    pub fn queue_msg(&mut self, msg: &S2C) {
+        let json = serde_json::to_string(msg).expect("Serialization failed");
+        self.write_buffer.extend_from_slice(json.as_bytes());
+        self.write_buffer.push(b'\n');
+    }
+
+    pub fn try_flush(&mut self) -> Result<(), StreamErr> {
+        while !self.write_buffer.is_empty() {
+            match self.stream.write(&self.write_buffer) {
+                Ok(0) => return Err(StreamErr::ConnectionEnded),
+                Ok(n) => {
+                    self.write_buffer.drain(..n);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => return Ok(()),
+                Err(_) => return Err(StreamErr::ConnectionEnded),
+            }
+        }
+        Ok(())
     }
 }
 
@@ -160,7 +181,7 @@ impl Server {
                                 println!("Client successfully assigned to lobby");
                             }
                             Err(ServerErr::LobbyFull) => {
-                                let _ = Self::send_msg_to_client(&mut conn.stream, &S2C::LobbyFull);
+                                conn.queue_msg(&S2C::LobbyFull);
                             }
                             _ => {}
                         }
@@ -182,12 +203,24 @@ impl Server {
                 }
 
                 // Listen to associated lobby for updates to send to client
-                if let Some(ref lobby_link) = conn.lobby_link
-                    && let Ok(msg) = lobby_link.1.try_recv()
-                {
-                    let s2c_msg = S2C::L2S4C(msg);
-                    if Self::send_msg_to_client(&mut conn.stream, &s2c_msg).is_err() {
-                        eprintln!("[server] CLIENT (ID: {}) ERR SENDING MSG", conn.id);
+                let pending = if let Some(ref lobby_link) = conn.lobby_link {
+                    lobby_link.1.try_recv().ok()
+                } else {
+                    None
+                };
+                if let Some(msg) = pending {
+                    conn.queue_msg(&S2C::L2S4C(msg));
+                }
+
+                if let Err(StreamErr::ConnectionEnded) = conn.try_flush() {
+                    eprintln!("[server] CLIENT (ID: {}) DISCONNECTED ON WRITE.", conn.id);
+                    if let Some(ref client) = conn.client
+                        && let Some(lobby) = client.lobby
+                    {
+                        let _ = self.txs[lobby].send(S2L::Disconnection(client.id));
+                    }
+                    if !ended_conns.contains(&i) {
+                        ended_conns.push(i);
                     }
                 }
             }
@@ -229,6 +262,7 @@ impl Server {
             client: None,
             id: conn_id,
             read_buffer: Vec::new(),
+            write_buffer: Vec::new(),
         };
         self.conns.push(conn);
     }
@@ -249,13 +283,5 @@ impl Server {
             return Ok((c2s_tx, s2c_rx));
         }
         Err(ServerErr::LobbyFull)
-    }
-
-    pub fn send_msg_to_client(stream: &mut TcpStream, msg: &S2C) -> std::io::Result<()> {
-        let json = serde_json::to_string(msg).expect("Serialization failed");
-        stream.write_all(json.as_bytes()).unwrap();
-        stream.write_all(b"\n").unwrap();
-        let _ = stream.flush();
-        Ok(())
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -5,11 +5,13 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bincode::{config, serde::decode_from_slice, serde::encode_to_vec};
+
 use crate::{r#const::SERVER_TICK, lobby::Lobby, thread_pool::ThreadPool};
 use common::{
     r#const::{IP_LOCAL, MAX_LOBBIES},
     packets::{C2S, C2S4L, L2S4C, S2C},
-    stream::StreamErr,
+    stream::{MAX_FRAME_BYTES, StreamErr},
 };
 
 pub enum S2L {
@@ -56,33 +58,41 @@ struct Connection {
 
 impl Connection {
     pub fn try_get_msg(&mut self) -> Result<Option<C2S>, StreamErr> {
-        let mut tmp_buf = [0u8; 1024];
-
+        let mut tmp_buf = [0u8; 4096];
         match self.stream.read(&mut tmp_buf) {
             Ok(0) => return Err(StreamErr::ConnectionEnded),
-            Ok(n) => {
-                self.read_buffer.extend(&tmp_buf[..n]);
-                if let Some(pos) = self.read_buffer.iter().position(|&b| b == b'\n') {
-                    let line = self.read_buffer[..pos].to_vec();
-
-                    self.read_buffer.drain(..=pos);
-
-                    let line_str = String::from_utf8_lossy(&line);
-                    return serde_json::from_str(&line_str)
-                        .map(Some)
-                        .map_err(|_| StreamErr::SerializationErr);
-                }
-                Ok(None)
-            }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-            Err(_) => Err(StreamErr::ConnectionEnded),
+            Ok(n) => self.read_buffer.extend_from_slice(&tmp_buf[..n]),
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+            Err(_) => return Err(StreamErr::ConnectionEnded),
         }
+
+        if self.read_buffer.len() < 4 {
+            return Ok(None);
+        }
+        let len = u32::from_le_bytes(self.read_buffer[..4].try_into().unwrap());
+        if len > MAX_FRAME_BYTES {
+            return Err(StreamErr::SerializationErr);
+        }
+        let frame_end = 4 + len as usize;
+        if self.read_buffer.len() < frame_end {
+            return Ok(None);
+        }
+        let result =
+            decode_from_slice::<C2S, _>(&self.read_buffer[4..frame_end], config::standard())
+                .map(|(msg, _)| Some(msg))
+                .map_err(|_| StreamErr::SerializationErr);
+        self.read_buffer.drain(..frame_end);
+        result
     }
 
     pub fn queue_msg(&mut self, msg: &S2C) {
-        let json = serde_json::to_string(msg).expect("Serialization failed");
-        self.write_buffer.extend_from_slice(json.as_bytes());
-        self.write_buffer.push(b'\n');
+        let bytes = encode_to_vec(msg, config::standard()).expect("Serialization failed");
+        let len: u32 = bytes
+            .len()
+            .try_into()
+            .expect("Outgoing frame exceeds u32 length");
+        self.write_buffer.extend_from_slice(&len.to_le_bytes());
+        self.write_buffer.extend_from_slice(&bytes);
     }
 
     pub fn try_flush(&mut self) -> Result<(), StreamErr> {


### PR DESCRIPTION
## Summary
- `send_msg_to_client` called `write_all().unwrap()` on a non-blocking `TcpStream`, so any time the kernel send buffer was momentarily full (typical when sending the initial map payload) the server panicked with `Os { code: 11, kind: WouldBlock }`.
- Replace the direct-write helper with a per-connection `write_buffer`. `queue_msg` appends serialized `S2C` messages + `\n`; `try_flush` drains as much as the socket accepts each tick and leaves the remainder for the next tick.
- `WouldBlock` is treated as backpressure; any other write error is treated as a disconnect and routed through the same cleanup path as a read-side `ConnectionEnded` (notify lobby, drop the connection).

## Test plan
- [x] `cargo build --bin server --bin client` clean
- [x] `cargo clippy --bin server` introduces no new warnings on the touched code
- [x] End-to-end: server + client; client reaches `Received map` / `Received main packet` (previously triggered the panic during initial-state send)

## Known follow-ups (not in this PR)
- `write_buffer` is unbounded — a stuck client will grow it without limit. Should cap and treat as disconnect.
- `queue_msg` allocates an intermediate `String`; switching to `serde_json::to_writer(&mut self.write_buffer, msg)` removes one alloc + one copy per message.
- Pre-existing read-side bug: `try_get_msg` returns `Ok(None)` on `WouldBlock` without checking `read_buffer`, so a pipelined message that arrived in the same `read()` can stall until more bytes come in.