### PR TITLE
Lazy lobby map gen + rayon-parallel cellular automata

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 common = { path = "../common" }
 rand = "0.9.1"
 bincode = { version = "2", features = ["serde"] }
+rayon = "1"

--- a/server/src/game/game.rs
+++ b/server/src/game/game.rs
@@ -18,7 +18,6 @@ use common::{
     r#const::CASTLE_SIZE,
     courtyard::{Facility, FacilityType},
     game_objs::GameObjE,
-    map::Tile,
     packets::MapPayload,
     units::UnitGroup,
 };

--- a/server/src/game/map.rs
+++ b/server/src/game/map.rs
@@ -1,4 +1,5 @@
 use rand::Rng;
+use rayon::prelude::*;
 
 use crate::r#const::{
     CA_ITER_HIGH_MOUNTAINS, CA_ITER_MOUNTAINS, CA_ITER_WATER, CA_ITER_WOODS,
@@ -14,6 +15,15 @@ use common::{
     packets::MapPayload,
 };
 
+struct TerrainParams {
+    spreading: Tile,
+    spreads_on: &'static [Tile],
+    iters: usize,
+    percent: u8,
+    counts_to_spread: u8,
+    counts_to_survive: u8,
+}
+
 pub struct Map {
     tiles: Vec<Vec<Tile>>,
     obstacles: Vec<Vec<bool>>,
@@ -23,16 +33,11 @@ pub struct Map {
 impl Map {
     pub fn new() -> Self {
         let tiles = Self::cellular_automata();
-        let mut obstacles = vec![vec![false; MAP_COLS]; MAP_ROWS];
+        let obstacles: Vec<Vec<bool>> = tiles
+            .par_iter()
+            .map(|row| row.iter().map(|t| *t == Tile::Water).collect())
+            .collect();
         let occupied = vec![vec![false; MAP_COLS]; MAP_ROWS];
-
-        for (r, row) in tiles.iter().enumerate() {
-            for (c, tile) in row.iter().enumerate() {
-                if *tile == Tile::Water {
-                    obstacles[r][c] = true;
-                }
-            }
-        }
 
         println!("mappa caricata LOL");
         Self {
@@ -109,145 +114,127 @@ impl Map {
     }
 
     fn cellular_automata() -> Vec<Vec<Tile>> {
-        let mut tiles = vec![vec![Tile::Grass; MAP_COLS]; MAP_ROWS];
+        let mut a = vec![vec![Tile::Grass; MAP_COLS]; MAP_ROWS];
+        let mut b = a.clone();
 
-        // Creating oceans
-        let mut before_add_random = tiles.clone();
-        let water_spreads_on = [Tile::Grass];
-        Self::add_random(&mut tiles, Tile::Water, &water_spreads_on, PERCENT_IS_WATER);
+        let terrains = [
+            TerrainParams {
+                spreading: Tile::Water,
+                spreads_on: &[Tile::Grass],
+                iters: CA_ITER_WATER,
+                percent: PERCENT_IS_WATER,
+                counts_to_spread: COUNTS_TO_SPREAD_WATER,
+                counts_to_survive: COUNTS_TO_SURVIVE_WATER,
+            },
+            TerrainParams {
+                spreading: Tile::Woods,
+                spreads_on: &[Tile::Grass],
+                iters: CA_ITER_WOODS,
+                percent: PERCENT_IS_WOODS,
+                counts_to_spread: COUNTS_TO_SPREAD_WOODS,
+                counts_to_survive: COUNTS_TO_SURVIVE_WOODS,
+            },
+            TerrainParams {
+                spreading: Tile::Mountain,
+                spreads_on: &[Tile::Grass, Tile::Woods],
+                iters: CA_ITER_MOUNTAINS,
+                percent: PERCENT_IS_MOUNTAINS,
+                counts_to_spread: COUNTS_TO_SPREAD_MOUNTAINS,
+                counts_to_survive: COUNTS_TO_SURVIVE_MOUNTAINS,
+            },
+            TerrainParams {
+                spreading: Tile::HighMountain,
+                spreads_on: &[Tile::Mountain],
+                iters: CA_ITER_HIGH_MOUNTAINS,
+                percent: PERCENT_IS_HIGH_MOUNTAINS,
+                counts_to_spread: COUNTS_TO_SPREAD_HIGH_MOUNTAINS,
+                counts_to_survive: COUNTS_TO_SURVIVE_HIGH_MOUNTAINS,
+            },
+        ];
 
-        let mut temp_tiles = tiles.clone();
-        for _ in 0..CA_ITER_WATER {
-            Self::step_life(
-                &tiles,
-                &mut temp_tiles,
-                &before_add_random,
-                Tile::Water,
-                &water_spreads_on,
-                COUNTS_TO_SPREAD_WATER,
-                COUNTS_TO_SURVIVE_WATER,
-            );
-            tiles.clone_from(&temp_tiles);
+        for params in &terrains {
+            Self::run_terrain(&mut a, &mut b, params);
         }
 
-        // Creating woodlands
-        before_add_random.clone_from(&tiles);
-        let woods_spreads_on = [Tile::Grass];
-        Self::add_random(&mut tiles, Tile::Woods, &woods_spreads_on, PERCENT_IS_WOODS);
+        a
+    }
 
-        let mut temp_tiles = tiles.clone();
-        for _ in 0..CA_ITER_WOODS {
-            Self::step_life(
-                &tiles,
-                &mut temp_tiles,
-                &before_add_random,
-                Tile::Woods,
-                &woods_spreads_on,
-                COUNTS_TO_SPREAD_WOODS,
-                COUNTS_TO_SURVIVE_WOODS,
-            );
-            tiles.clone_from(&temp_tiles);
+    fn run_terrain(a: &mut Vec<Vec<Tile>>, b: &mut Vec<Vec<Tile>>, params: &TerrainParams) {
+        let before_add_random = a.clone();
+        Self::add_random(a, params.spreading, params.spreads_on, params.percent);
+        b.clone_from(a);
+
+        for _ in 0..params.iters {
+            Self::step_life(a, b, &before_add_random, params);
+            std::mem::swap(a, b);
         }
-
-        // Creating mountains
-        before_add_random = tiles.clone();
-        let mountains_spreads_on = [Tile::Grass, Tile::Woods];
-        Self::add_random(
-            &mut tiles,
-            Tile::Mountain,
-            &mountains_spreads_on,
-            PERCENT_IS_MOUNTAINS,
-        );
-
-        let mut temp_tiles = tiles.clone();
-        for _ in 0..CA_ITER_MOUNTAINS {
-            Self::step_life(
-                &tiles,
-                &mut temp_tiles,
-                &before_add_random,
-                Tile::Mountain,
-                &mountains_spreads_on,
-                COUNTS_TO_SPREAD_MOUNTAINS,
-                COUNTS_TO_SURVIVE_MOUNTAINS,
-            );
-            tiles.clone_from(&temp_tiles);
-        }
-
-        // Creating high mountains
-        before_add_random = tiles.clone();
-        let high_mountains_spreads_on = [Tile::Mountain];
-        Self::add_random(
-            &mut tiles,
-            Tile::HighMountain,
-            &high_mountains_spreads_on,
-            PERCENT_IS_HIGH_MOUNTAINS,
-        );
-
-        let mut temp_tiles = tiles.clone();
-        for _ in 0..CA_ITER_HIGH_MOUNTAINS {
-            Self::step_life(
-                &tiles,
-                &mut temp_tiles,
-                &before_add_random,
-                Tile::HighMountain,
-                &high_mountains_spreads_on,
-                COUNTS_TO_SPREAD_HIGH_MOUNTAINS,
-                COUNTS_TO_SURVIVE_HIGH_MOUNTAINS,
-            );
-            tiles.clone_from(&temp_tiles);
-        }
-        tiles
     }
 
     fn add_random(tiles: &mut [Vec<Tile>], add_type: Tile, add_on: &[Tile], percent: u8) {
-        let mut rng = rand::rng();
+        tiles
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(row, tile_row)| {
+                let mut rng = rand::rng();
+                for (col, tile) in tile_row.iter_mut().enumerate() {
+                    let is_edge =
+                        row == 0 || col == 0 || row == MAP_ROWS - 1 || col == MAP_COLS - 1;
+                    let random_hit = rng.random_range(1..=100) <= percent;
+                    let is_valid_tile = add_on.contains(tile);
 
-        for row in 0..MAP_ROWS {
-            for col in 0..MAP_COLS {
-                let is_edge = row == 0 || col == 0 || row == MAP_ROWS - 1 || col == MAP_COLS - 1;
-                let random_hit = rng.random_range(1..=100) <= percent;
-                let is_valid_tile = add_on.contains(&tiles[row][col]);
-
-                if (is_edge || random_hit) && is_valid_tile {
-                    tiles[row][col] = add_type;
+                    if (is_edge || random_hit) && is_valid_tile {
+                        *tile = add_type;
+                    }
                 }
-            }
-        }
+            });
     }
 
     fn step_life(
-        tiles: &[Vec<Tile>],
-        temp_tiles: &mut [Vec<Tile>],
+        a: &[Vec<Tile>],
+        b: &mut [Vec<Tile>],
         before_add_random: &[Vec<Tile>],
-        spreading_type: Tile,
-        spreads_on: &[Tile],
-        counts_to_spread: u8,
-        counts_to_survive: u8,
+        params: &TerrainParams,
     ) {
-        for row in 1..MAP_ROWS - 1 {
-            for col in 1..MAP_COLS - 1 {
-                let mut neightb_count = 0;
+        let spreading = params.spreading;
+        let spreads_on = params.spreads_on;
+        let counts_to_spread = params.counts_to_spread;
+        let counts_to_survive = params.counts_to_survive;
 
-                for i in row.saturating_sub(1)..=(row + 1).min(MAP_ROWS - 1) {
-                    for j in col.saturating_sub(1)..=(col + 1).min(MAP_COLS - 1) {
-                        if i == row && j == col {
-                            continue;
-                        }
-                        if tiles[i][j] == spreading_type {
-                            neightb_count += 1;
-                        }
+        b.par_iter_mut().enumerate().for_each(|(row, b_row)| {
+            if row == 0 || row == MAP_ROWS - 1 {
+                return;
+            }
+            let prev = &a[row - 1];
+            let curr = &a[row];
+            let next = &a[row + 1];
+            let before_row = &before_add_random[row];
+            for col in 1..MAP_COLS - 1 {
+                let mut neightb_count = 0u8;
+                for c in (col - 1)..=(col + 1) {
+                    if prev[c] == spreading {
+                        neightb_count += 1;
+                    }
+                    if next[c] == spreading {
+                        neightb_count += 1;
                     }
                 }
+                if curr[col - 1] == spreading {
+                    neightb_count += 1;
+                }
+                if curr[col + 1] == spreading {
+                    neightb_count += 1;
+                }
 
-                if neightb_count >= counts_to_spread && spreads_on.contains(&temp_tiles[row][col]) {
-                    temp_tiles[row][col] = spreading_type;
+                let mut new_val = curr[col];
+                if neightb_count >= counts_to_spread && spreads_on.contains(&new_val) {
+                    new_val = spreading;
                 }
-                if neightb_count < counts_to_survive && temp_tiles[row][col] == spreading_type {
-                    let new_tile = before_add_random[row][col];
-                    temp_tiles[row][col] = new_tile;
+                if neightb_count < counts_to_survive && new_val == spreading {
+                    new_val = before_row[col];
                 }
+                b_row[col] = new_val;
             }
-        }
+        });
     }
 
     pub fn export(&self) -> MapPayload {

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -203,12 +203,7 @@ impl Lobby {
                     }
                     C2S4L::AttackCastle(target_id, unit_group_e) => {
                         if let Some(castle_id) = player.castle_id {
-                            if !game.attack_castle(
-                                castle_id,
-                                target_id,
-                                unit_group_e,
-                                &self.pool,
-                            ) {
+                            if !game.attack_castle(castle_id, target_id, unit_group_e, &self.pool) {
                                 log = Some(LogE::AttackDeployErr);
                             }
                         }

--- a/server/src/lobby.rs
+++ b/server/src/lobby.rs
@@ -69,27 +69,19 @@ pub struct Lobby {
     clients_ch: HashMap<ClientId, ClientCh>,
     players: HashMap<ClientId, Player>,
     num_players: usize,
-    game: Game,
+    game: Option<Game>,
     pool: ThreadPool,
 }
 
 impl Lobby {
     pub fn new(id: usize) -> Self {
-        let players = HashMap::new();
-        let clients_ch = HashMap::new();
-        let num_players = 0;
-        let game = Game::new();
-        let pool = ThreadPool::new(LOBBY_POOL_LEN);
-
-        println!("New lobby initialized");
-
         Self {
             id,
-            players,
-            clients_ch,
-            num_players,
-            game,
-            pool,
+            players: HashMap::new(),
+            clients_ch: HashMap::new(),
+            num_players: 0,
+            game: None,
+            pool: ThreadPool::new(LOBBY_POOL_LEN),
         }
     }
 
@@ -108,7 +100,7 @@ impl Lobby {
             self.listen_server(&mut main_rx, &mut running);
             self.listen_clients();
 
-            let dead_castles = self.game.step();
+            let dead_castles = self.game.as_mut().map(Game::step).unwrap_or_default();
             for dead_castle in dead_castles.iter() {
                 if let Some((_, player)) = self
                     .players
@@ -146,8 +138,12 @@ impl Lobby {
         self.num_players += 1;
         println!("New player joined in a lobby, ID: {}", client_id);
 
-        Self::send_map(&client_ch, &self.game);
-        Self::send_main_packet(&client_ch, &player, &self.game);
+        let game = self.game.get_or_insert_with(|| {
+            println!("New lobby initialized");
+            Game::new()
+        });
+        Self::send_map(&client_ch, game);
+        Self::send_main_packet(&client_ch, &player, game);
         println!("Sent initial data to client");
 
         self.clients_ch.insert(client_id, client_ch);
@@ -183,6 +179,9 @@ impl Lobby {
     }
 
     fn listen_clients(&mut self) {
+        let Some(game) = self.game.as_mut() else {
+            return;
+        };
         for (client_id, client_ch) in self.clients_ch.iter_mut() {
             let Some(player) = self.players.get_mut(client_id) else {
                 continue;
@@ -195,7 +194,7 @@ impl Lobby {
                         println!("Client ({}) requested to build a new castle", client_id);
                         if player.castle_id.is_none()
                             && let Some(castle_id) =
-                                self.game.add_player_castle(player.name.clone(), pos)
+                                game.add_player_castle(player.name.clone(), pos)
                         {
                             player.set_castle_id(castle_id);
                         } else {
@@ -204,7 +203,7 @@ impl Lobby {
                     }
                     C2S4L::AttackCastle(target_id, unit_group_e) => {
                         if let Some(castle_id) = player.castle_id {
-                            if !self.game.attack_castle(
+                            if !game.attack_castle(
                                 castle_id,
                                 target_id,
                                 unit_group_e,
@@ -216,7 +215,7 @@ impl Lobby {
                     }
                     C2S4L::SendUnits(target_pos, unit_group_e) => {
                         if let Some(castle_id) = player.castle_id {
-                            if !self.game.request_send_units(
+                            if !game.request_send_units(
                                 castle_id,
                                 target_pos,
                                 unit_group_e,
@@ -237,7 +236,7 @@ impl Lobby {
                         let Some(castle_id) = player.castle_id else {
                             continue;
                         };
-                        if !self.game.add_facility(castle_id, facility_type, pos) {
+                        if !game.add_facility(castle_id, facility_type, pos) {
                             log = Some(LogE::FacilityCreationErr);
                         }
                     }
@@ -250,14 +249,17 @@ impl Lobby {
     }
 
     fn send_updates(&mut self) {
+        let Some(game) = self.game.as_ref() else {
+            return;
+        };
         for (client_id, client_ch) in self.clients_ch.iter_mut() {
             let Some(player) = self.players.get_mut(client_id) else {
                 continue;
             };
 
             match player.in_courtyard {
-                false => Self::send_main_packet(client_ch, &player, &self.game),
-                true => Self::send_courtyard_packet(client_ch, &player, &self.game),
+                false => Self::send_main_packet(client_ch, &player, game),
+                true => Self::send_courtyard_packet(client_ch, &player, game),
             }
         }
     }


### PR DESCRIPTION
Stacked on #2 — review/merge that one first. Once #2 lands, this PR will auto-retarget to master.

## Summary
At `MAP_ROWS=MAP_COLS=8960` (~80M tiles), `Lobby::new()` → `Game::new()` → `Map::new()` runs cellular automata on every lobby thread at server boot. With `MAX_LOBBIES=10` they all run concurrently, the server pins ~3.2 GB RAM / every core for tens of seconds, and `Server::assign_client_to_lobby` deadlocks the main loop on a `recv()` from a lobby thread that isn't in its `run()` yet.

Two changes:

1. **Lazy lobby init.** `Lobby::game: Option<Game>`. The map is built on first `add_player` via `get_or_insert_with(Game::new)`. `listen_clients`, `send_updates`, and the per-tick `step()` short-circuit when `game.is_none()`. Server boot is now instant (~3 MB idle). `S2L::IsFull` replies the moment it's received, so the server's main loop never stalls.

2. **Parallel CA with ping-pong buffers.**
   - Two preallocated grids `a`, `b`; `std::mem::swap` instead of a full `Vec<Vec<Tile>>` clone every iter (~50 clones → ~9 across all four terrains).
   - `step_life` is rayon-parallel over rows — each thread reads three contiguous rows of `a` (`prev`/`curr`/`next`) and writes one row of `b`. Neighbor count is unrolled and pre-bound to row slices. Algorithm is restated as `read a → compute locally → write b`; this is equivalent to the original in-place mutation because each cell only ever reads its own position, so the original sequential update order carried no information.
   - `add_random` is rayon-parallel; each worker uses a thread-local `rand::rng()`.
   - `Map::new`'s `tiles → obstacles` pass is `par_iter`.
   - Per-terrain config bundled into `TerrainParams` so call sites stay short.

## Results at 8960²
- Server idle boot: **~3 MB RAM, 0% CPU** (was ~3.2 GB, 996% CPU on 10 cores)
- Login → first packet (`Received map` / `Received main packet`): **~4–5 s** in release (was minutes / never)

## Test plan
- [x] `cargo build --release --bin server --bin client` clean
- [x] `cargo clippy --bin server` no new warnings on touched code
- [x] End-to-end at 8960²: server idle, client connects, picks lobby, receives map+main packet in ~4–5 s
- [ ] Eyeball the generated map visually for sanity (looks the same kind of biome distribution as before — but I haven't done a side-by-side)