### PR TITLE
Add stone-wall border around courtyard view

### DIFF
--- a/client/src/assets.rs
+++ b/client/src/assets.rs
@@ -91,6 +91,23 @@ impl TileAsset {
     }
 }
 
+pub struct WallAsset {
+    pub corner_tl: TermCell,
+    pub corner_tr: TermCell,
+    pub corner_bl: TermCell,
+    pub corner_br: TermCell,
+    pub edge_top: TermCell,
+    pub edge_bottom: TermCell,
+    pub edge_left: TermCell,
+    pub edge_right: TermCell,
+}
+
+impl WallAsset {
+    pub fn get_asset(night: bool) -> &'static Self {
+        if night { &NIGHT_WALL } else { &DAY_WALL }
+    }
+}
+
 pub struct FacilityAsset;
 
 impl FacilityAsset {
@@ -209,6 +226,30 @@ pub const DEPLOYED_UNITS_ART_SIZE: (usize, usize) =
 
 pub const ERR_ART: &[&[TermCell]] = &[&[TermCell::ERR]];
 pub const ERR_ART_SIZE: (usize, usize) = (ERR_ART.len(), ERR_ART[0].len());
+
+// Courtyard walls
+
+pub const DAY_WALL: WallAsset = WallAsset {
+    corner_tl: TermCell::new('╔', DAY_GREY_0, DAY_GREY_2),
+    corner_tr: TermCell::new('╗', DAY_GREY_0, DAY_GREY_2),
+    corner_bl: TermCell::new('╚', DAY_GREY_0, DAY_GREY_2),
+    corner_br: TermCell::new('╝', DAY_GREY_0, DAY_GREY_2),
+    edge_top: TermCell::new('═', DAY_GREY_0, DAY_GREY_2),
+    edge_bottom: TermCell::new('═', DAY_GREY_0, DAY_GREY_2),
+    edge_left: TermCell::new('║', DAY_GREY_0, DAY_GREY_2),
+    edge_right: TermCell::new('║', DAY_GREY_0, DAY_GREY_2),
+};
+
+pub const NIGHT_WALL: WallAsset = WallAsset {
+    corner_tl: TermCell::new('╔', NIGHT_GREY_0, NIGHT_GREY_2),
+    corner_tr: TermCell::new('╗', NIGHT_GREY_0, NIGHT_GREY_2),
+    corner_bl: TermCell::new('╚', NIGHT_GREY_0, NIGHT_GREY_2),
+    corner_br: TermCell::new('╝', NIGHT_GREY_0, NIGHT_GREY_2),
+    edge_top: TermCell::new('═', NIGHT_GREY_0, NIGHT_GREY_2),
+    edge_bottom: TermCell::new('═', NIGHT_GREY_0, NIGHT_GREY_2),
+    edge_left: TermCell::new('║', NIGHT_GREY_0, NIGHT_GREY_2),
+    edge_right: TermCell::new('║', NIGHT_GREY_0, NIGHT_GREY_2),
+};
 
 // Facilities
 

--- a/client/src/renderer/mod_central.rs
+++ b/client/src/renderer/mod_central.rs
@@ -61,7 +61,7 @@ impl ModCentral {
             }
             CameraLocation::Courtyard => {
                 let title = format!("Castli | courtyard {}", camera_coord);
-                let mut cells = Self::draw_courtyard();
+                let mut cells = Self::draw_courtyard(game_state.time.night);
                 Self::add_facilities_to_courtyard(
                     &mut cells,
                     &game_state.facilities,
@@ -174,13 +174,43 @@ impl ModCentral {
         cells
     }
 
-    fn draw_courtyard() -> Vec<Vec<TermCell>> {
+    fn draw_courtyard(night: bool) -> Vec<Vec<TermCell>> {
         let mut cells = vec![vec![TermCell::ERR; Renderer::FOV_COLS]; Renderer::FOV_ROWS];
-        for i in 0..(COURTYARD_ROWS / 2).min(Renderer::FOV_ROWS) {
-            for j in 0..COURTYARD_COLS.min(Renderer::FOV_COLS) {
-                cells[i][j] = BKG_EL;
+        let rows = (COURTYARD_ROWS / 2).min(Renderer::FOV_ROWS);
+        let cols = COURTYARD_COLS.min(Renderer::FOV_COLS);
+
+        for row in cells.iter_mut().take(rows) {
+            for cell in row.iter_mut().take(cols) {
+                *cell = BKG_EL;
             }
         }
+
+        if rows < 2 || cols < 2 {
+            return cells;
+        }
+
+        let wall = WallAsset::get_asset(night);
+        let last_row = rows - 1;
+        let last_col = cols - 1;
+
+        let (top_row, rest) = cells.split_first_mut().expect("rows >= 2");
+        let (middle_rows, bottom_only) = rest.split_at_mut(last_row - 1);
+        let bottom_row = &mut bottom_only[0];
+
+        for cell in top_row.iter_mut().take(cols).skip(1).take(last_col - 1) {
+            *cell = wall.edge_top;
+        }
+        for cell in bottom_row.iter_mut().take(cols).skip(1).take(last_col - 1) {
+            *cell = wall.edge_bottom;
+        }
+        for row in middle_rows.iter_mut() {
+            row[0] = wall.edge_left;
+            row[last_col] = wall.edge_right;
+        }
+        top_row[0] = wall.corner_tl;
+        top_row[last_col] = wall.corner_tr;
+        bottom_row[0] = wall.corner_bl;
+        bottom_row[last_col] = wall.corner_br;
 
         cells
     }


### PR DESCRIPTION
Stacked on #4. Auto-retargets to master once #2 → #3 → #4 land.

## Summary
The courtyard's central panel renders as a flat field of `BKG_EL` (`.`-on-black). This adds a stone-wall border around the playable area so the courtyard reads as an enclosed space.

- New `WallAsset` struct (4 corners + 4 edges) with `DAY_WALL` / `NIGHT_WALL` consts, grey palette (`GREY_0` fg on `GREY_2` bg), box-drawing glyphs (`╔═╗║╚╝`).
- `draw_courtyard` now takes `night: bool`, fills the interior with `BKG_EL`, then paints the 1-cell wall border before facilities are drawn on top.
- The pre-existing index-only loop in the `BKG_EL` fill is rewritten with `iter_mut().take(...)` to avoid the clippy nag (project rule: no lint suppressions). The new edge-painting code uses `split_first_mut`/`split_at_mut` to obtain disjoint `&mut` borrows on the top, middle, and bottom rows.

## Test plan
- [x] `cargo build --bin client` clean
- [x] `cargo clippy --bin client` no new warnings on touched code
- [x] `cargo fmt` idempotent
- [ ] Visual sanity check in a real terminal — the harness can't render. Specifically confirm: walls show on courtyard view, day/night palette swaps with `time.night`, facilities still draw correctly within the walled area.